### PR TITLE
Add store module with contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ await kitcart.blog.getBlogs({ limit: 5 });
 await kitcart.blog.postComment(blogId, 'Great post!', 5);
 ```
 ___
+## 🏬 Store
+```js
+await kitcart.store.getStoreDetails();
+await kitcart.store.submitContactForm({
+  name: 'John Doe',
+  phone_number: '08012345678',
+  email_address: 'john@example.com',
+  subject: 'Inquiry',
+  message: 'Hello!',
+});
+```
+___
 ## 📌 Token Management
 ```js
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import paymentsModule from './modules/payments.js';
 import ordersModule from './modules/orders.js';
 import billingModule from './modules/billing.js';
 import blogModule from './modules/blog.js';
+import storeModule from './modules/store.js';
 
 
 export default class Kitcart {
@@ -29,6 +30,7 @@ export default class Kitcart {
     this.orders = ordersModule(this.http);
     this.billing = billingModule(this.http);
     this.blog = blogModule(this.http);
+    this.store = storeModule(this.http);
   }
 
   setToken(token) {

--- a/src/modules/store.js
+++ b/src/modules/store.js
@@ -1,0 +1,14 @@
+export default function storeModule(http) {
+  return {
+    getStoreDetails: () => http.get('/'),
+
+    submitContactForm: ({ name, phone_number, email_address, subject, message }) =>
+      http.post('/contact-form', {
+        name,
+        phone_number,
+        email_address,
+        subject,
+        message,
+      }),
+  };
+}


### PR DESCRIPTION
## Summary
- add a Store module for store details and contact form
- expose the new module on the SDK instance
- document Store usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849de8c0ee88322ab9a4b660b3651d6