### PR TITLE
Add demo test.js and update README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,12 @@ kitcart.clearToken();
 ```
 ___
 ## 🧪 Local Test File
-Run node test.js to try sample API calls from your own store.
+An example `test.js` file is included to demonstrate basic API calls. Replace the `storeId` in the file with your own and run:
+```bash
+node test.js
+```
+
+This will fetch a few products from your store and print them to the console.
 ___
 
 ## 🛠️ Contributing

--- a/test.js
+++ b/test.js
@@ -1,0 +1,15 @@
+import Kitcart from './src/index.js';
+
+// Replace 'demo_store_id' with your actual store ID to test with real data.
+const kitcart = new Kitcart({ storeId: 'demo_store_id' });
+
+async function main() {
+  try {
+    const response = await kitcart.products.getProducts({ limit: 2 });
+    console.log('Products:', response.data);
+  } catch (err) {
+    console.error('Error calling API:', err.message);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- document `test.js` usage in README
- add minimal `test.js` example with dummy store id

## Testing
- `npm test` *(fails: Missing script)*
- `npx eslint .` *(fails: could not find config)*

------
https://chatgpt.com/codex/tasks/task_e_6849dea0ba5883228aa092461dfbc1f2