### PR TITLE
Add linting and formatting configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "es2021": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "semi": true,
+  "printWidth": 80
+}

--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ ___
 Run node test.js to try sample API calls from your own store.
 ___
 
+## 🧹 Linting & Formatting
+
+Run ESLint to check code quality and Prettier to format files:
+
+```bash
+npm run lint
+npm run format
+```
+
+___
+
 ## 🛠️ Contributing
 Pull requests and suggestions welcome. Make sure to keep modules modular and light.
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./.eslintrc.json');

--- a/package.json
+++ b/package.json
@@ -21,5 +21,10 @@
   "bugs": {
     "url": "https://github.com/Kitcart/kitcart-js-sdk/issues"
   },
-  "homepage": "https://github.com/Kitcart/kitcart-js-sdk#readme"
+  "homepage": "https://github.com/Kitcart/kitcart-js-sdk#readme",
+  "scripts": {
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint .",
+    "format": "prettier --write ."
+  }
 }
+


### PR DESCRIPTION
## Summary
- configure ESLint and Prettier
- add helper ESLint config loader
- document linting and formatting commands
- add npm scripts for lint and format

## Testing
- `npm run lint`
- `npm run format` *(reverted formatting changes)*

------
https://chatgpt.com/codex/tasks/task_e_6849deb7c6a88322ae08bb5f474b689e